### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -36,6 +36,8 @@ jobs:
   build:
     needs: [test]
     name: Build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   test:
     name: Test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Levalicious/server-sequential-thinking/security/code-scanning/2](https://github.com/Levalicious/server-sequential-thinking/security/code-scanning/2)

To fix the problem, we should add a `permissions` block to the `build` job in `.github/workflows/typescript.yml`, immediately after the job name and before the `runs-on` key (or directly after `needs`, following conventional order). This block should specify the minimal required permissions, which for build jobs is typically `contents: read`. This change ensures the job does not inherit broader repository or organizational permissions, adhering to the principle of least privilege. No changes are required to other jobs unless they also lack a `permissions` block and do not require write access (in this snippet, only `build` is highlighted).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
